### PR TITLE
Add support for both keyserver and URL to prevent breakage

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -14,7 +14,7 @@
   when: apt_repo is defined
   register: apt_require_update
 
-- name: main | add repository key via keyserevr
+- name: main | add repository key via keyserver
   apt_key:
     id='{{ item.key_id }}'
     keyserver='{{ item.key_server }}'

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -14,13 +14,22 @@
   when: apt_repo is defined
   register: apt_require_update
 
-- name: main | add repository key
+- name: main | add repository key via keyserevr
   apt_key:
     id='{{ item.key_id }}'
     keyserver='{{ item.key_server }}'
     state=present
   with_items: apt_repo
-  when: item.key_url and item.keyserver is defined
+  when: item.key_id and item.key_server is defined
+  register: apt_require_update
+
+- name: main | add repository key via url
+  apt_key:
+    id='{{ item.key_id }}'
+    url='{{ item.key_url }}'
+    state=present
+  with_items: apt_repo
+  when: item.key_id and item.key_url is defined
   register: apt_require_update
 
 - name: main | apt-cache update (changed)

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -6,10 +6,19 @@
         - repo_url: "deb https://get.docker.com/ubuntu docker main"
           key_id: '36A1D7869245C8950F966E92D8576A8BA88D21E9'
           key_server: 'keyserver.ubuntu.com'
+        - repo_url: "deb http://nginx.org/packages/{{ ansible_distribution | lower }}/ {{ ansible_distribution_release }} nginx"
+          key_id: '7BD9BF62'
+          key_url: 'http://nginx.org/keys/nginx_signing.key'
   tasks:
-    - name: test | check custom repo exists
+    - name: test | check docker repo exists
       stat: path=/etc/apt/sources.list.d/get_docker_com_ubuntu.list
-      register: repo
+      register: repo_docker
     - assert:
         that:
-          - repo.stat.exists and repo.stat.isreg
+          - repo_docker.stat.exists and repo_docker.stat.isreg
+    - name: test | check nginx repo exists
+      stat: path=/etc/apt/sources.list.d/nginx_org_packages_ubuntu.list
+      register: repo_nginx
+    - assert:
+        that:
+          - repo_nginx.stat.exists and repo_nginx.stat.isreg


### PR DESCRIPTION
#6 changed to download keys from a keyserver, but would have breaking changes for anyone using the old syntax. This PR adds support for both methods.